### PR TITLE
Explicit weights_only = False in torch load

### DIFF
--- a/GroundingDINO/groundingdino/util/inference.py
+++ b/GroundingDINO/groundingdino/util/inference.py
@@ -30,7 +30,7 @@ def load_model(model_config_path: str, model_checkpoint_path: str, device: str =
     args = SLConfig.fromfile(model_config_path)
     args.device = device
     model = build_model(args)
-    checkpoint = torch.load(model_checkpoint_path, map_location="cpu")
+    checkpoint = torch.load(model_checkpoint_path, map_location="cpu", weights_only=False)
     model.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
     model.eval()
     return model


### PR DESCRIPTION
Explicity pass `weights_only` param to torch.load since its default value has changed starting from torch 2.6.